### PR TITLE
Fix usage comments in step2 scripts

### DIFF
--- a/step2_container_bin_packing_no_rotation.py
+++ b/step2_container_bin_packing_no_rotation.py
@@ -5,9 +5,9 @@ import sys
 import json
 from ortools.sat.python import cp_model
 
-# Usage: python container_bin_packing-1-geometry.py <input_json_file>
+# Usage: python step2_container_bin_packing_no_rotation.py <input_json_file>
 if len(sys.argv) < 2:
-    print("Usage: python container_bin_packing-1-geometry.py <input_json_file>")
+    print("Usage: python step2_container_bin_packing_no_rotation.py <input_json_file>")
     sys.exit(1)
 
 input_file = sys.argv[1]

--- a/step2_container_bin_packing_rotation_allowed.py
+++ b/step2_container_bin_packing_rotation_allowed.py
@@ -7,9 +7,9 @@ import sys
 from ortools.sat.python import cp_model
 from load_utils import load_data_from_json
 
-# Usage: python container_bin_packing-1-geometry.py <input_json_file>
+# Usage: python step2_container_bin_packing_rotation_allowed.py <input_json_file>
 if len(sys.argv) < 2:
-    print("Usage: python container_bin_packing-1-geometry.py <input_json_file>")
+    print("Usage: python step2_container_bin_packing_rotation_allowed.py <input_json_file>")
     sys.exit(1)
 
 


### PR DESCRIPTION
## Summary
- update help comments in step2 scripts to refer to their own filenames

## Testing
- `python -m py_compile step2_container_bin_packing_no_rotation.py step2_container_bin_packing_rotation_allowed.py`


------
https://chatgpt.com/codex/tasks/task_b_68764bbd5868832292bc5c2d846be451