### PR TITLE
Fix rotation variable in partition check

### DIFF
--- a/step1_box_partition_in_containers.py
+++ b/step1_box_partition_in_containers.py
@@ -67,7 +67,11 @@ def run(data):
             if all(box_size[d] <= container_size[d] for d in range(3)):
                 fits = True
         if not fits:
-            raise ValueError("Item {} with size {} does not fit in container of size {} (rotation={})".format(item_ids[i], box_size, container_size, rotation))
+            raise ValueError(
+                "Item {} with size {} does not fit in container of size {} (rotation={})".format(
+                    item_ids[i], box_size, container_size, item_rotations[i]
+                )
+            )
 
 
 


### PR DESCRIPTION
## Summary
- fix crash in partition step's fit check when printing rotation details

## Testing
- `pytest -q` *(fails: visualize_solution missing param, load_utils unpack error)*

------
https://chatgpt.com/codex/tasks/task_b_6879ef60bd6c83228418bfc6e3c825d6