### PR TITLE
Fix output filename parameter

### DIFF
--- a/step1_box_partition_in_containers.py
+++ b/step1_box_partition_in_containers.py
@@ -6,7 +6,7 @@ from ortools.sat.python import cp_model
 
 from step2_container_box_placement_in_container import run as step2_run 
 
-def run(data):
+def run(data, output_filename):
     # Read rotation property (default to 'free' if not present)
     #rotation = data.get('rotation', 'free')
 
@@ -270,10 +270,10 @@ def run(data):
 
     # Write JSON file
 
-    with open(ouput_filename, 'w', encoding='utf-8') as fjson:
+    with open(output_filename, 'w', encoding='utf-8') as fjson:
         import json as _json
         _json.dump(output_json, fjson, indent=2)
-    print(f'JSON results also written to {ouput_filename}')
+    print(f'JSON results also written to {output_filename}')
 
     # Run step 2: box placement in containers
     if step_2_settings_file is None:
@@ -299,9 +299,9 @@ if __name__ == "__main__":
         print('Usage: python container_bin_packing.py <input_json_file> <output_json_file>')
         sys.exit(1)
     input_filename = sys.argv[1]
-    ouput_filename = sys.argv[2]
+    output_filename = sys.argv[2]
     # Read input data from JSON file
 
     with open(input_filename, 'r') as f:
         data = json.load(f)
-        run(data)
+        run(data, output_filename)


### PR DESCRIPTION
## Summary
- rename `ouput_filename` variable to `output_filename`
- pass the new parameter into `run`
- update the `__main__` script to use the parameter

## Testing
- `pytest -q` *(fails: visualize_solution() missing argument and too many values to unpack)*

------
https://chatgpt.com/codex/tasks/task_b_6879f6674bf48322832330fc21058771